### PR TITLE
[refac]: UserApiController 관심사 분리

### DIFF
--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
@@ -37,7 +37,7 @@ export class FavoriteSummonerApiController {
     description: `
     소환사 즐겨찾기 추가 시 name, tier, win, lose, profileIconId, puuid, summonerId, leaguePoint, rank를 입력받습니다. \n
     소환사 즐겨찾기 추가 시 입력값을 누락한 경우 400 에러를 출력합니다. \n
-    소환사 즐겨찾기 추가 시 즐겨찾기 한도가 초과된 경우 400 에러를 출력합니다. \n
+    소환사 즐겨찾기 추가 시 즐겨찾기 한도가 초과된 경우 403 에러를 출력합니다. \n
     헤더에 토큰 값을 제대로 설정하지 않으면 401 에러를 출력합니다. \n
     `,
   })

--- a/apps/api/src/user/UserApiController.ts
+++ b/apps/api/src/user/UserApiController.ts
@@ -23,7 +23,6 @@ import { UnauthorizedError } from '@app/common-config/response/swagger/common/er
 import { BadRequestError } from '@app/common-config/response/swagger/common/error/BadRequestError';
 import { FcmTokenUpdateSuccess } from '@app/common-config/response/swagger/domain/user/FcmTokenUpdateSuccess';
 import { PushUpdateSuccess } from '@app/common-config/response/swagger/domain/user/PushUpdateSuccess';
-import { User } from '@app/entity/domain/user/User.entity';
 
 @Controller('user')
 @ApiTags('유저 API')
@@ -66,10 +65,7 @@ export class UserApiController {
   ): Promise<ResponseEntity<string>> {
     try {
       await this.userApiService.updateFcmToken(
-        await User.updateFcmToken(
-          userUpdateFcmTokenDto.firebaseToken,
-          userDto.deviceId,
-        ),
+        await userUpdateFcmTokenDto.toEntity(userDto.deviceId),
       );
       return ResponseEntity.OK_WITH('FCM 토큰 수정에 성공했습니다.');
     } catch (error) {
@@ -116,7 +112,7 @@ export class UserApiController {
   ): Promise<ResponseEntity<string>> {
     try {
       await this.userApiService.updatePush(
-        await User.updatePush(userDto.deviceId, userUpdatePushDto.isPush),
+        await userUpdatePushDto.toEntity(userDto.deviceId),
       );
       return ResponseEntity.OK_WITH('푸시알림 허용 여부 수정에 성공했습니다.');
     } catch (error) {

--- a/apps/api/src/user/dto/UserUpdateFcmTokenReq.dto.ts
+++ b/apps/api/src/user/dto/UserUpdateFcmTokenReq.dto.ts
@@ -13,4 +13,8 @@ export class UserUpdateFcmTokenReq {
   @IsNotEmpty()
   @IsString()
   firebaseToken: string;
+
+  toEntity(deviceId: string): Promise<User> {
+    return User.updateFcmToken(this.firebaseToken, deviceId);
+  }
 }

--- a/apps/api/src/user/dto/UserUpdatePushReq.dto.ts
+++ b/apps/api/src/user/dto/UserUpdatePushReq.dto.ts
@@ -1,3 +1,4 @@
+import { User } from '@app/entity/domain/user/User.entity';
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { IsNotEmpty, IsBoolean } from 'class-validator';
@@ -12,4 +13,8 @@ export class UserUpdatePushReq {
   @IsNotEmpty()
   @IsBoolean()
   isPush: boolean;
+
+  toEntity(deviceId: string): Promise<User> {
+    return User.updatePush(deviceId, this.isPush);
+  }
 }


### PR DESCRIPTION
## 작업사항
1. presentation Layer에서 바로 Domain Layer로 접근하는 문제가 있었음.
2. DTO를 활용해서 Entity 객체를 생성하도록 변경
3. presentation Layer가 Domain Layer를 직접 접근하는 문제 해결
4. 이를 통해 아키텍처의 한 계층의 변경이 다른 계층의 구성 요소에 영향을 미치지 않도록 격리

## 참고

[계층형 아키텍처](https://jojoldu.tistory.com/603?category=1011740)