### PR TITLE
[refac]: 로그인 단위테스트 실패 코드 수정

### DIFF
--- a/apps/api/test/unit/domain/auth/AuthApiService.spec.ts
+++ b/apps/api/test/unit/domain/auth/AuthApiService.spec.ts
@@ -5,6 +5,7 @@ import { UserRepositoryStub } from '../../stub/user/UserRepositoryStub';
 import { UserApiRepositoryStub } from '../../stub/user/UserApiRepositoryStub';
 import { UserApiQueryRepositoryStub } from '../../stub/user/UserApiQueryRepositoryStub';
 import { User } from '@app/entity/domain/user/User.entity';
+import { NotFoundException } from '@nestjs/common';
 
 describe('AuthApiService', () => {
   let userRepository;
@@ -75,13 +76,12 @@ describe('AuthApiService', () => {
       userApiQueryRepository,
       jwtService,
     );
-    // when
-    try {
+
+    await expect(async () => {
+      // when
       await sut.signin(await User.signinTest());
-    } catch (error) {
+
       // then
-      expect(error.response.message).toBe('Not Found');
-      expect(error.response.statusCode).toBe(404);
-    }
+    }).rejects.toThrowError(new NotFoundException());
   });
 });


### PR DESCRIPTION
## 작업사항

1. 기존에는 try ~ catch를 활용해서 테스트 코드를 검증
2. 만약 예외없이 완료 되는 경우에는 테스트가 성공하지 않았는데도 불구하고, 테스트를 성공적으로 완료했다고 한 후 종료 시킴
3. try ~ catch를 활용하면 예상한 에러와 다른 에러가 발생할 대 추적하기 힘듦
4. expect로 변경한 후에는 예외없이 완료 되는 경우 의도한대로 throw가 발생하지 않으면 테스트가 실패함
5. 또한 예상하지 못한 에러가 발생할 경우, 에러를 추적할 수 있음


## 참고

[Jest로 Error 검증시 catch 보다는 expect](https://jojoldu.tistory.com/656)
