### PR TITLE
[feat]: 소환사 즐겨찾기 조회 API 로직 추가

### DIFF
--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
@@ -6,6 +6,7 @@ import {
   Body,
   Controller,
   Delete,
+  Get,
   Inject,
   Post,
   UseGuards,
@@ -35,6 +36,7 @@ import { FavoriteSummonerIdReq } from './dto/FavoriteSummonerIdReq.dto';
 import { FavoriteSummonerDeleteSuccess } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteSuccess';
 import { FavoriteSummonerDeleteFail } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteFail';
 import { FavoriteSummonerDeleteNotFound } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteNotFound';
+import { FavoriteSummonerRes } from './dto/FavoriteSummonerRes.dto';
 
 @Controller('favoriteSummoner')
 @ApiTags('소환사 즐겨찾기 API')
@@ -150,6 +152,25 @@ export class FavoriteSummonerApiController {
         return ResponseEntity.NOT_FOUND_WITH(error.message);
       }
       return ResponseEntity.ERROR_WITH('소환사 즐겨찾기 취소에 실패했습니다.');
+    }
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get()
+  async getFollow(@CurrentUser() userDto: UserReq) {
+    try {
+      const data: FavoriteSummonerRes[] =
+        await this.favoriteSummonerApiService.getFavoriteSummoner(
+          await userDto.toEntity(),
+        );
+
+      return ResponseEntity.OK_WITH_DATA(
+        '소환사 즐겨찾기 조회에 성공했습니다.',
+        data,
+      );
+    } catch (error) {
+      this.logger.error(`dto = ${JSON.stringify(userDto)}`, error);
+      return ResponseEntity.ERROR_WITH('소환사 즐겨찾기 조회에 실패했습니다.');
     }
   }
 }

--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiController.ts
@@ -37,6 +37,8 @@ import { FavoriteSummonerDeleteSuccess } from '@app/common-config/response/swagg
 import { FavoriteSummonerDeleteFail } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteFail';
 import { FavoriteSummonerDeleteNotFound } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerDeleteNotFound';
 import { FavoriteSummonerRes } from './dto/FavoriteSummonerRes.dto';
+import { FavoriteSummonerReadFail } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadFail';
+import { FavoriteSummonerReadSuccess } from '@app/common-config/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadSuccess';
 
 @Controller('favoriteSummoner')
 @ApiTags('소환사 즐겨찾기 API')
@@ -155,6 +157,27 @@ export class FavoriteSummonerApiController {
     }
   }
 
+  @ApiOperation({
+    summary: '소환사 즐겨찾기 조회',
+    description: `
+    헤더에 토큰 값을 제대로 설정하지 않으면 401 에러를 출력합니다. \n
+    소환사 즐겨찾기 조회 시 조회를 실패하면 500 에러를 출력합니다. \n
+    소환사 즐겨찾기 조회 시 조회를 성공하면 200 코드를 출력합니다. \n
+    `,
+  })
+  @ApiOkResponse({
+    description: '소환사 즐겨찾기 조회에 성공했습니다.',
+    type: FavoriteSummonerReadSuccess,
+  })
+  @ApiUnauthorizedResponse({
+    description: '잘못된 Authorization입니다.',
+    type: UnauthorizedError,
+  })
+  @ApiInternalServerErrorResponse({
+    description: '소환사 즐겨찾기 조회에 실패했습니다.',
+    type: FavoriteSummonerReadFail,
+  })
+  @ApiBearerAuth('Authorization')
   @UseGuards(JwtAuthGuard)
   @Get()
   async getFollow(@CurrentUser() userDto: UserReq) {

--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiQueryRepository.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiQueryRepository.ts
@@ -1,7 +1,9 @@
+import { SummonerRecord } from '@app/entity/domain/summonerRecord/SummonerRecord.entity';
 import { FavoriteSummoner } from '@app/entity/domain/favoriteSummoner/FavoriteSummoner.entity';
 import { FavoriteSummonerId } from '@app/entity/domain/favoriteSummoner/FavoriteSummonerId';
 import { plainToInstance } from 'class-transformer';
 import { createQueryBuilder, EntityRepository, Repository } from 'typeorm';
+import { FavoriteSummonerJoinSummonerRecord } from '@app/entity/domain/favoriteSummoner/FavoriteSummonerJoinSummonerRecord';
 
 @EntityRepository(FavoriteSummoner)
 export class FavoriteSummonerApiQueryRepository extends Repository<FavoriteSummoner> {
@@ -26,6 +28,15 @@ export class FavoriteSummonerApiQueryRepository extends Repository<FavoriteSummo
     return plainToInstance(FavoriteSummonerId, row);
   }
 
+  async findAllFavoriteSummoners(
+    userId: number,
+  ): Promise<FavoriteSummonerJoinSummonerRecord[]> {
+    const row: SummonerRecord[] = await this.findAllJoinSummonerRecordByUserId(
+      userId,
+    );
+    return plainToInstance(FavoriteSummonerJoinSummonerRecord, row);
+  }
+
   private async findOneByUserAndSummonerId(userId: number, summonerId: string) {
     const queryBuilder = createQueryBuilder()
       .select(['id'])
@@ -34,6 +45,31 @@ export class FavoriteSummonerApiQueryRepository extends Repository<FavoriteSummo
       .andWhere(`favoriteSummoner.summoner_id =:summonerId`, { summonerId });
 
     return await queryBuilder.getRawOne();
+  }
+
+  private async findAllJoinSummonerRecordByUserId(userId: number) {
+    const queryBuilder = createQueryBuilder()
+      .select([
+        'summonerRecord.id',
+        'summonerRecord.name',
+        'summonerRecord.tier',
+        'summonerRecord.win',
+        'summonerRecord.lose',
+        'summonerRecord.profileIconId',
+        'summonerRecord.puuid',
+        'summonerRecord.summonerId',
+        'summonerRecord.rank',
+        'summonerRecord.leaguePoint',
+      ])
+      .from(FavoriteSummoner, 'favoriteSummoner')
+      .innerJoin(
+        SummonerRecord,
+        'summonerRecord',
+        'summonerRecord.summoner_id = favoriteSummoner.summoner_id',
+      )
+      .where(`favoriteSummoner.user_id =:userId`, { userId });
+
+    return await queryBuilder.getRawMany();
   }
 
   private async findOneSoftDelete(userId: number, summonerId: string) {

--- a/apps/api/src/favoriteSummoner/FavoriteSummonerApiService.ts
+++ b/apps/api/src/favoriteSummoner/FavoriteSummonerApiService.ts
@@ -13,6 +13,8 @@ import { SummonerRecord } from '@app/entity/domain/summonerRecord/SummonerRecord
 import { UserReq } from '../user/dto/UserReq.dto';
 import { FavoriteSummonerIdReq } from './dto/FavoriteSummonerIdReq.dto';
 import { FavoriteSummonerId } from '@app/entity/domain/favoriteSummoner/FavoriteSummonerId';
+import { User } from '@app/entity/domain/user/User.entity';
+import { FavoriteSummonerRes } from './dto/FavoriteSummonerRes.dto';
 
 @Injectable()
 export class FavoriteSummonerApiService {
@@ -76,6 +78,10 @@ export class FavoriteSummonerApiService {
     await this.favoriteSummonerRepository.softDelete(favoriteSummonerId.id);
   }
 
+  async getFavoriteSummoner(userDto: User): Promise<FavoriteSummonerRes[]> {
+    return await this.findAllFavoriteSummoners(userDto.id);
+  }
+
   private async isSummonerRecordBySummonerId(
     summonerId: string,
   ): Promise<boolean> {
@@ -108,6 +114,19 @@ export class FavoriteSummonerApiService {
     return await this.favoriteSummonerApiQueryRepository.findFavoriteSummonerId(
       userId,
       summonerId,
+    );
+  }
+
+  private async findAllFavoriteSummoners(
+    userId: number,
+  ): Promise<FavoriteSummonerRes[]> {
+    const favoriteSummonerJoinSummonerRecords =
+      await this.favoriteSummonerApiQueryRepository.findAllFavoriteSummoners(
+        userId,
+      );
+    return favoriteSummonerJoinSummonerRecords.map(
+      favoriteSummonerJoinSummonerRecord =>
+        new FavoriteSummonerRes(favoriteSummonerJoinSummonerRecord),
     );
   }
 }

--- a/apps/api/src/favoriteSummoner/dto/FavoriteSummonerRes.dto.ts
+++ b/apps/api/src/favoriteSummoner/dto/FavoriteSummonerRes.dto.ts
@@ -33,46 +33,55 @@ export class FavoriteSummonerRes {
     return this._id;
   }
 
+  @ApiProperty()
   @Expose()
   get name(): string {
     return this._name;
   }
 
+  @ApiProperty()
   @Expose()
   get tier(): string {
     return this._tier;
   }
 
+  @ApiProperty()
   @Expose()
   get win(): number {
     return this._win;
   }
 
+  @ApiProperty()
   @Expose()
   get lose(): number {
     return this._lose;
   }
 
+  @ApiProperty()
   @Expose()
   get puuid(): string {
     return this._puuid;
   }
 
+  @ApiProperty()
   @Expose()
   get rank(): string {
     return this._rank;
   }
 
+  @ApiProperty()
   @Expose()
   get profileIconId(): string {
     return this._profileIconId;
   }
 
+  @ApiProperty()
   @Expose()
   get summonerId(): string {
     return this._summonerId;
   }
 
+  @ApiProperty()
   @Expose()
   get leaguePoint(): number {
     return this._leaguePoint;

--- a/apps/api/src/favoriteSummoner/dto/FavoriteSummonerRes.dto.ts
+++ b/apps/api/src/favoriteSummoner/dto/FavoriteSummonerRes.dto.ts
@@ -1,0 +1,80 @@
+import { Exclude, Expose } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { FavoriteSummonerJoinSummonerRecord } from '@app/entity/domain/favoriteSummoner/FavoriteSummonerJoinSummonerRecord';
+
+export class FavoriteSummonerRes {
+  @Exclude() private readonly _id: number;
+  @Exclude() private readonly _name: string;
+  @Exclude() private readonly _tier: string;
+  @Exclude() private readonly _win: number;
+  @Exclude() private readonly _lose: number;
+  @Exclude() private readonly _puuid: string;
+  @Exclude() private readonly _rank: string;
+  @Exclude() private readonly _profileIconId: string;
+  @Exclude() private readonly _summonerId: string;
+  @Exclude() private readonly _leaguePoint: number;
+
+  constructor(summonerRecord: FavoriteSummonerJoinSummonerRecord) {
+    this._id = summonerRecord.id;
+    this._name = summonerRecord.name;
+    this._tier = summonerRecord.tier;
+    this._win = summonerRecord.win;
+    this._lose = summonerRecord.lose;
+    this._puuid = summonerRecord.puuid;
+    this._rank = summonerRecord.rank;
+    this._profileIconId = summonerRecord.profileIconId;
+    this._summonerId = summonerRecord.summonerId;
+    this._leaguePoint = summonerRecord.leaguePoint;
+  }
+
+  @ApiProperty()
+  @Expose()
+  get id(): number {
+    return this._id;
+  }
+
+  @Expose()
+  get name(): string {
+    return this._name;
+  }
+
+  @Expose()
+  get tier(): string {
+    return this._tier;
+  }
+
+  @Expose()
+  get win(): number {
+    return this._win;
+  }
+
+  @Expose()
+  get lose(): number {
+    return this._lose;
+  }
+
+  @Expose()
+  get puuid(): string {
+    return this._puuid;
+  }
+
+  @Expose()
+  get rank(): string {
+    return this._rank;
+  }
+
+  @Expose()
+  get profileIconId(): string {
+    return this._profileIconId;
+  }
+
+  @Expose()
+  get summonerId(): string {
+    return this._summonerId;
+  }
+
+  @Expose()
+  get leaguePoint(): number {
+    return this._leaguePoint;
+  }
+}

--- a/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadFail.ts
+++ b/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadFail.ts
@@ -1,0 +1,16 @@
+import { InternalServerError } from '@app/common-config/response/swagger/common/error/InternalServerError';
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+
+@ApiExtraModels()
+export class FavoriteSummonerReadFail extends PickType(InternalServerError, [
+  'statusCode',
+  'data',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '실패 메시지',
+    example: '소환사 즐겨찾기 조회에 실패했습니다.',
+    description: '소환사 즐겨찾기 조회에 실패했습니다.',
+  })
+  message: string;
+}

--- a/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadSuccess.ts
+++ b/libs/common-config/src/response/swagger/domain/favoriteSummoner/FavoriteSummonerReadSuccess.ts
@@ -1,0 +1,49 @@
+import { ApiExtraModels, ApiProperty, PickType } from '@nestjs/swagger';
+import { FavoriteSummonerRes } from '../../../../../../../apps/api/src/favoriteSummoner/dto/FavoriteSummonerRes.dto';
+import { OkSuccess } from '../../common/OkSuccess';
+
+@ApiExtraModels()
+export class FavoriteSummonerReadSuccess extends PickType(OkSuccess, [
+  'statusCode',
+] as const) {
+  @ApiProperty({
+    type: 'string',
+    title: '성공 메시지',
+    example: '소환사 즐겨찾기 조회에 성공했습니다.',
+    description: '소환사 즐겨찾기 조회에 성공했습니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    type: FavoriteSummonerRes,
+    title: '성공 메시지',
+    example: [
+      {
+        id: '44',
+        name: 'test',
+        tier: 'test',
+        win: '1',
+        lose: '1',
+        puuid: 'test',
+        rank: 'test',
+        profileIconId: 'test',
+        summonerId: 'test3',
+        leaguePoint: 1,
+      },
+      {
+        id: '45',
+        name: 'test',
+        tier: 'test',
+        win: '1',
+        lose: '1',
+        puuid: 'test',
+        rank: 'test',
+        profileIconId: 'test',
+        summonerId: 'test2',
+        leaguePoint: 1,
+      },
+    ],
+    description: '소환사 즐겨찾기 조회에 성공했습니다.',
+  })
+  data: FavoriteSummonerRes[];
+}

--- a/libs/entity/src/domain/favoriteSummoner/FavoriteSummonerJoinSummonerRecord.ts
+++ b/libs/entity/src/domain/favoriteSummoner/FavoriteSummonerJoinSummonerRecord.ts
@@ -1,0 +1,33 @@
+import { Expose } from 'class-transformer';
+
+export class FavoriteSummonerJoinSummonerRecord {
+  @Expose({ name: 'summonerRecord_id' })
+  id: number;
+
+  @Expose({ name: 'summonerRecord_name' })
+  name: string;
+
+  @Expose({ name: 'summonerRecord_tier' })
+  tier: string;
+
+  @Expose({ name: 'summonerRecord_win' })
+  win: number;
+
+  @Expose({ name: 'summonerRecord_lose' })
+  lose: number;
+
+  @Expose({ name: 'summonerRecord_puuid' })
+  puuid: string;
+
+  @Expose({ name: 'summonerRecord_rank' })
+  rank: string;
+
+  @Expose({ name: 'summonerRecord_profile_icon_id' })
+  profileIconId: string;
+
+  @Expose({ name: 'summonerRecord_summoner_id' })
+  summonerId: string;
+
+  @Expose({ name: 'summonerRecord_league_point' })
+  leaguePoint: number;
+}


### PR DESCRIPTION

## 작업사항

1. 소환사 즐겨찾기 조회 정보 직렬화 설정
2. 스네이크 케이스인 테이블 컬럼 정보를 카멜케이스로 변경

To Do List
1. Swagger 설정
2. 테스트 코드 작성

## 관계된 이슈, PR 

#6 
