### PR TITLE
[fix]: 소환사 즐겨찾기 추가 API 수정

### DIFF
--- a/apps/api/src/favoriteSummoner/dto/FavoriteSummonerReq.dto.ts
+++ b/apps/api/src/favoriteSummoner/dto/FavoriteSummonerReq.dto.ts
@@ -21,7 +21,6 @@ export class FavoriteSummonerReq {
     required: true,
   })
   @Expose()
-  @IsNotEmpty()
   @IsString()
   tier: string;
 
@@ -51,7 +50,6 @@ export class FavoriteSummonerReq {
     required: true,
   })
   @Expose()
-  @IsNotEmpty()
   @IsString()
   profileIconId: string;
 
@@ -92,7 +90,6 @@ export class FavoriteSummonerReq {
     required: true,
   })
   @Expose()
-  @IsNotEmpty()
   @IsString()
   rank: string;
 

--- a/libs/entity/migrations/1648031937397-SummonerRecordNullable.ts
+++ b/libs/entity/migrations/1648031937397-SummonerRecordNullable.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class SummonerRecordNullable1648031937397 implements MigrationInterface {
+    name = 'SummonerRecordNullable1648031937397'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "summoner_record" ALTER COLUMN "tier" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "summoner_record" ALTER COLUMN "profile_icon_id" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "summoner_record" ALTER COLUMN "rank" DROP NOT NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "summoner_record" ALTER COLUMN "rank" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "summoner_record" ALTER COLUMN "profile_icon_id" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "summoner_record" ALTER COLUMN "tier" SET NOT NULL`);
+    }
+
+}

--- a/libs/entity/src/domain/summonerRecord/SummonerRecord.entity.ts
+++ b/libs/entity/src/domain/summonerRecord/SummonerRecord.entity.ts
@@ -22,6 +22,7 @@ export class SummonerRecord extends BaseTimeEntity {
 
   @Column({
     type: 'varchar',
+    nullable: true,
   })
   tier: string;
 
@@ -38,6 +39,7 @@ export class SummonerRecord extends BaseTimeEntity {
   @Column({
     type: 'varchar',
     transformer: new StringValueTransformer(),
+    nullable: true,
   })
   profileIconId: string;
 
@@ -59,6 +61,7 @@ export class SummonerRecord extends BaseTimeEntity {
 
   @Column({
     type: 'varchar',
+    nullable: true,
   })
   rank: string;
 
@@ -84,14 +87,14 @@ export class SummonerRecord extends BaseTimeEntity {
   ): Promise<SummonerRecord> {
     const summonerRecord = new SummonerRecord();
     summonerRecord.name = name;
-    summonerRecord.tier = tier;
+    summonerRecord.tier = tier ? tier : null;
     summonerRecord.win = win;
     summonerRecord.lose = lose;
-    summonerRecord.profileIconId = profileIconId;
+    summonerRecord.profileIconId = profileIconId ? profileIconId : null;
     summonerRecord.puuid = puuid;
     summonerRecord.summonerId = summonerId;
     summonerRecord.leaguePoint = leaguePoint;
-    summonerRecord.rank = rank;
+    summonerRecord.rank = rank ? rank : null;
     return summonerRecord;
   }
 }


### PR DESCRIPTION
## 작업사항
1. 입력 값에서, tier, profileIconId, rank의 경우 입력값이 들어오지 않아도 데이터가 저장되게끔 수정
2. Null 값 허용하도록 엔티티 수정

## 관계된 이슈, PR 