### PR TITLE
[test]: 소환사 즐겨찾기 삭제 테스트 로직 추가

### DIFF
--- a/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
+++ b/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
@@ -84,4 +84,76 @@ describe('FavoriteSummonerApiService', () => {
       new NotFoundException('즐겨찾기 한도가 초과되었습니다.'),
     );
   });
+
+  it('즐겨찾기 삭제에 성공했습니다.', async () => {
+    // given
+    favoriteSummonerRepository = new FavoriteSummonerRepositoryStub();
+    summonerRecordRepository = new SummonerRecordRepositoryStub();
+    summonerRecordApiQueryRepository =
+      new SummonerRecordApiQueryRepositoryStub();
+    favoriteSummonerApiQueryRepository =
+      new FavoriteSummonerApiQueryRepositoryStub();
+
+    const sut = new FavoriteSummonerApiService(
+      favoriteSummonerRepository,
+      summonerRecordRepository,
+      summonerRecordApiQueryRepository,
+      favoriteSummonerApiQueryRepository,
+    );
+    // when
+    const actual = await sut.deleteFavoriteSummoner(
+      UserReq.of('test', 1),
+      FavoriteSummonerReq.of(
+        'test',
+        'test',
+        1,
+        1,
+        6,
+        'test',
+        'test',
+        1,
+        'test',
+      ),
+    );
+    // then
+    expect(actual).toBeUndefined();
+  });
+
+  it('즐겨찾기 한도가 초과되었습니다.', async () => {
+    // given
+    favoriteSummonerRepository = new FavoriteSummonerRepositoryStub();
+    summonerRecordRepository = new SummonerRecordRepositoryStub();
+    summonerRecordApiQueryRepository =
+      new SummonerRecordApiQueryRepositoryStub();
+    favoriteSummonerApiQueryRepository =
+      new FavoriteSummonerApiQueryRepositoryStub();
+
+    const sut = new FavoriteSummonerApiService(
+      favoriteSummonerRepository,
+      summonerRecordRepository,
+      summonerRecordApiQueryRepository,
+      favoriteSummonerApiQueryRepository,
+    );
+
+    await expect(async () => {
+      // when
+      await sut.deleteFavoriteSummoner(
+        UserReq.of('test2', 2),
+        FavoriteSummonerReq.of(
+          'test',
+          'test',
+          1,
+          1,
+          6,
+          'test',
+          'test',
+          1,
+          'test',
+        ),
+      );
+      // then
+    }).rejects.toThrowError(
+      new NotFoundException('삭제할 즐겨찾기를 조회할 수 없습니다.'),
+    );
+  });
 });

--- a/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerApiQueryRepositoryStub.ts
+++ b/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerApiQueryRepositoryStub.ts
@@ -4,6 +4,7 @@ import { FavoriteSummonerApiQueryRepository } from '../../../../src/favoriteSumm
 export class FavoriteSummonerApiQueryRepositoryStub extends FavoriteSummonerApiQueryRepository {
   private readonly favoriteSummonerLimitCount: number = 5;
   private readonly favoriteSummonerNonLimitCount: number = 1;
+  private readonly notFindFavoriteSummonerId: number = 2;
 
   constructor() {
     super();
@@ -19,6 +20,15 @@ export class FavoriteSummonerApiQueryRepositoryStub extends FavoriteSummonerApiQ
     userId: number,
     summonerId: string,
   ): Promise<FavoriteSummonerId> {
+    const dto = FavoriteSummonerId.from(1);
+    return dto;
+  }
+
+  override async findFavoriteSummonerId(
+    userId: number,
+    summonerId: string,
+  ): Promise<FavoriteSummonerId> {
+    if (userId === this.notFindFavoriteSummonerId) return;
     const dto = FavoriteSummonerId.from(1);
     return dto;
   }

--- a/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerRepositoryStub.ts
+++ b/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerRepositoryStub.ts
@@ -22,6 +22,10 @@ export class FavoriteSummonerRepositoryStub {
     }
   }
 
+  softDelete() {
+    return UpdateResult.Result();
+  }
+
   restore() {
     return UpdateResult.Result();
   }


### PR DESCRIPTION
## 작업사항

- 소환사 즐겨찾기 삭제 service 성공 단위 테스트 로직 추가
- 소환사 즐겨찾기 삭제 service 실패 단위 테스트 로직 추가

