### PR TITLE
[test]: 소환사 즐겨찾기 조회 테스트 로직 추가

### DIFF
--- a/apps/api/src/favoriteSummoner/dto/FavoriteSummonerReq.dto.ts
+++ b/apps/api/src/favoriteSummoner/dto/FavoriteSummonerReq.dto.ts
@@ -51,7 +51,7 @@ export class FavoriteSummonerReq {
   })
   @Expose()
   @IsNotEmpty()
-  @IsString()
+  @IsNumber()
   profileIconId: number;
 
   @ApiProperty({

--- a/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
+++ b/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
@@ -5,7 +5,7 @@ import { SummonerRecordApiQueryRepositoryStub } from '../../stub/summonerRecord/
 import { FavoriteSummonerApiQueryRepositoryStub } from '../../stub/favoriteSummoner/FavoriteSummonerApiQueryRepositoryStub';
 import { FavoriteSummonerReq } from '../../../../../../apps/api/src/favoriteSummoner/dto/FavoriteSummonerReq.dto';
 import { UserReq } from '../../../../../../apps/api/src/user/dto/UserReq.dto';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 
 describe('FavoriteSummonerApiService', () => {
   let favoriteSummonerRepository;
@@ -81,7 +81,7 @@ describe('FavoriteSummonerApiService', () => {
       );
       // then
     }).rejects.toThrowError(
-      new NotFoundException('즐겨찾기 한도가 초과되었습니다.'),
+      new ForbiddenException('즐겨찾기 한도가 초과되었습니다.'),
     );
   });
 
@@ -119,7 +119,7 @@ describe('FavoriteSummonerApiService', () => {
     expect(actual).toBeUndefined();
   });
 
-  it('즐겨찾기 한도가 초과되었습니다.', async () => {
+  it('삭제할 즐겨찾기를 조회할 수 없습니다.', async () => {
     // given
     favoriteSummonerRepository = new FavoriteSummonerRepositoryStub();
     summonerRecordRepository = new SummonerRecordRepositoryStub();

--- a/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
+++ b/apps/api/test/unit/domain/favoriteSummoner/FavoriteSummonerApiService.spec.ts
@@ -6,6 +6,7 @@ import { FavoriteSummonerApiQueryRepositoryStub } from '../../stub/favoriteSummo
 import { FavoriteSummonerReq } from '../../../../../../apps/api/src/favoriteSummoner/dto/FavoriteSummonerReq.dto';
 import { UserReq } from '../../../../../../apps/api/src/user/dto/UserReq.dto';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { User } from '@app/entity/domain/user/User.entity';
 
 describe('FavoriteSummonerApiService', () => {
   let favoriteSummonerRepository;
@@ -155,5 +156,37 @@ describe('FavoriteSummonerApiService', () => {
     }).rejects.toThrowError(
       new NotFoundException('삭제할 즐겨찾기를 조회할 수 없습니다.'),
     );
+  });
+
+  it('즐겨찾기 조회에 성공했습니다.', async () => {
+    // given
+    favoriteSummonerRepository = new FavoriteSummonerRepositoryStub();
+    summonerRecordRepository = new SummonerRecordRepositoryStub();
+    summonerRecordApiQueryRepository =
+      new SummonerRecordApiQueryRepositoryStub();
+    favoriteSummonerApiQueryRepository =
+      new FavoriteSummonerApiQueryRepositoryStub();
+
+    const sut = new FavoriteSummonerApiService(
+      favoriteSummonerRepository,
+      summonerRecordRepository,
+      summonerRecordApiQueryRepository,
+      favoriteSummonerApiQueryRepository,
+    );
+    // when
+    const actual = await sut.getFavoriteSummoner(
+      await User.jwtUserReq('test', 1),
+    );
+    // then
+    expect(actual[0].id).toBe(1);
+    expect(actual[0].name).toBe('test');
+    expect(actual[0].tier).toBe('test');
+    expect(actual[0].win).toBe(1);
+    expect(actual[0].lose).toBe(1);
+    expect(actual[0].puuid).toBe('test');
+    expect(actual[0].rank).toBe('test');
+    expect(actual[0].profileIconId).toBe(1);
+    expect(actual[0].summonerId).toBe('test');
+    expect(actual[0].leaguePoint).toBe(1);
   });
 });

--- a/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerApiQueryRepositoryStub.ts
+++ b/apps/api/test/unit/stub/favoriteSummoner/FavoriteSummonerApiQueryRepositoryStub.ts
@@ -1,5 +1,7 @@
 import { FavoriteSummonerId } from '@app/entity/domain/favoriteSummoner/FavoriteSummonerId';
+import { FavoriteSummonerJoinSummonerRecord } from '@app/entity/domain/favoriteSummoner/FavoriteSummonerJoinSummonerRecord';
 import { FavoriteSummonerApiQueryRepository } from '../../../../src/favoriteSummoner/FavoriteSummonerApiQueryRepository';
+import { FavoriteSummonerRes } from '../../../../src/favoriteSummoner/dto/FavoriteSummonerRes.dto';
 
 export class FavoriteSummonerApiQueryRepositoryStub extends FavoriteSummonerApiQueryRepository {
   private readonly favoriteSummonerLimitCount: number = 5;
@@ -31,5 +33,26 @@ export class FavoriteSummonerApiQueryRepositoryStub extends FavoriteSummonerApiQ
     if (userId === this.notFindFavoriteSummonerId) return;
     const dto = FavoriteSummonerId.from(1);
     return dto;
+  }
+
+  override async findAllFavoriteSummoners(
+    userId: number,
+  ): Promise<FavoriteSummonerRes[]> {
+    const dto = [];
+    dto.push(
+      FavoriteSummonerJoinSummonerRecord.of(
+        1,
+        'test',
+        'test',
+        1,
+        1,
+        'test',
+        'test',
+        1,
+        'test',
+        1,
+      ),
+    );
+    return dto.map(dto => new FavoriteSummonerRes(dto));
   }
 }

--- a/libs/entity/src/domain/favoriteSummoner/FavoriteSummonerJoinSummonerRecord.ts
+++ b/libs/entity/src/domain/favoriteSummoner/FavoriteSummonerJoinSummonerRecord.ts
@@ -30,4 +30,30 @@ export class FavoriteSummonerJoinSummonerRecord {
 
   @Expose({ name: 'summonerRecord_league_point' })
   leaguePoint: number;
+
+  static of(
+    id: number,
+    name: string,
+    tier: string,
+    win: number,
+    lose: number,
+    puuid: string,
+    rank: string,
+    profileIconId: number,
+    summonerId: string,
+    leaguePoint: number,
+  ): FavoriteSummonerJoinSummonerRecord {
+    const dto = new FavoriteSummonerJoinSummonerRecord();
+    dto.id = id;
+    dto.name = name;
+    dto.tier = tier;
+    dto.win = win;
+    dto.lose = lose;
+    dto.puuid = puuid;
+    dto.rank = rank;
+    dto.profileIconId = profileIconId;
+    dto.summonerId = summonerId;
+    dto.leaguePoint = leaguePoint;
+    return dto;
+  }
 }


### PR DESCRIPTION
## 작업사항

- 소환사 즐겨찾기 조회 service 성공 단위 테스트 로직 추가
- 즐겨찾기 추가시, 한도 초과가 될 경우 403 에러를 출력하도록 설정
- 즐겨찾기 삭제 실패 테스트 이름 변경
- 기존 number를 받아야하는 곳에 string 값을 받게 해둔 로직 수정

